### PR TITLE
fix: `published_at` being set even if `published: true` already set

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "test": "npm run test"
+  }
+}

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -93,8 +93,9 @@ published_at: "2020-01-01 00:00"
     expect(actual).toEqual(expected);
   });
 
-  test("published_at 未設定の場合は published_at を更新する", async () => {
+  test("published: true かつ published_at 未設定の場合は published_at を更新する", async () => {
     const updateParam: Partial<ZennMetadata> = {
+      published: true,
       published_at: "2021-01-01 00:00",
     };
 
@@ -104,7 +105,7 @@ title: "Productivity Weekly (20xx-xx-xx号)"
 emoji: ""
 type: "idea" # tech: 技術記事 / idea: アイデア
 topics: ["ProductivityWeekly", "生産性向上"]
-published: true 
+published: false
 ---`);
 
     const actual = await updateZennMetadata(updater, updateParam);
@@ -115,6 +116,32 @@ published: true
       topics: ["ProductivityWeekly", "生産性向上"],
       published: true,
       published_at: "2021-01-01 00:00",
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
+  test("published: true が設定されている場合は published_at を設定しない", async () => {
+    const updateParam: Partial<ZennMetadata> = {
+      published_at: "2023-12-27 10:00",
+    };
+
+    const updater = new Updater();
+    updater.load(`---
+title: "Productivity Weekly (20xx-xx-xxtrue号)"
+emoji: ""
+type: "idea" # tech: 技術記事 / idea: アイデア
+topics: ["ProductivityWeekly", "生産性向上"]
+published: true
+---`);
+
+    const actual = await updateZennMetadata(updater, updateParam);
+    const expected: Partial<ZennMetadata> = {
+      title: "Productivity Weekly (20xx-xx-xxtrue号)",
+      emoji: "",
+      type: "idea",
+      topics: ["ProductivityWeekly", "生産性向上"],
+      published: true,
     };
 
     expect(actual).toEqual(expected);

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -38,8 +38,9 @@ export async function updateZennMetadata(
   updater: Updater,
   updateParams: Partial<ZennMetadata>,
 ) {
-  const metadata = updater.get();
-  debug(`now metadata: ${JSON.stringify(metadata, null, 2)}`);
+  const oldMetadata = structuredClone(updater.get());
+  const newMetadata = structuredClone(updater.get());
+  debug(`now metadata: ${JSON.stringify(oldMetadata, null, 2)}`);
   debug(`input metadata: ${JSON.stringify(updateParams, null, 2)}`);
   for (const [key, value] of Object.entries(updateParams)) {
     if (value === "" || value === undefined) continue;
@@ -47,13 +48,17 @@ export async function updateZennMetadata(
     const publishedAtKey: keyof ZennMetadata = "published_at";
 
     // もしすでに `published_at` が設定されていたら更新しない
-    if (key === publishedAtKey && metadata.published_at !== undefined) continue;
+    if (key === publishedAtKey && oldMetadata.published_at !== undefined)
+      continue;
 
-    metadata[key] = value;
+    // もし `published: true` が設定されていたら `published_at` を更新しない
+    if (key === publishedAtKey && oldMetadata.published === true) continue;
+
+    newMetadata[key] = value;
   }
-  debug(`updated metadata: ${JSON.stringify(metadata, null, 2)}`);
+  debug(`updated metadata: ${JSON.stringify(newMetadata, null, 2)}`);
 
-  return metadata;
+  return newMetadata;
 }
 
 export async function validateMetadata(markdown: Buffer) {


### PR DESCRIPTION
Fixes #310

Prevent setting `published_at` when `published: true` is already set.

* **src/functions.ts**
  - Update `updateZennMetadata` to exclude `published_at` when `published: true`.
  - Add a check to skip updating `published_at` if `published: true` is already set.
* **src/__tests__/main.test.ts**
  - Add a test to verify `published_at` is not set when `published: true`.
  - Update existing test to include `published: true` and verify `published_at` is updated only when `published: false`.
* **.devcontainer.json**
  - Add a devcontainer configuration file with a test task.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/korosuke613/zenn-metadata-updater-action/issues/310?shareId=32e170ca-702d-4a90-b17e-c82bcf0f9fb6).