### PR TITLE
fix: exclude other markdowns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,8 @@ jobs:
       - run: "git log -m -1 --name-only --pretty=format: HEAD"
       - run: "git log -m -1 --name-only HEAD"
       - run: |
-          cp ./src/__tests__/invalidMarkdown.md .
+          mkdir -p articles
+          cp ./src/__tests__/invalidMarkdown.md ./articles
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git add -A

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -25,15 +25,10 @@ test("getFiles", async () => {
 });
 
 test("getMarkdowns", () => {
-  const input = [
-    "__tests__/sampleMarkdown.md",
-    ".eslintrc.js",
-    "test.md",
-    "src/main.ts",
-  ];
+  const input = [".eslintrc.js", "articles/test.md", "src/main.ts"];
 
   const markdownFiles = getMarkdowns(input);
-  const expected = ["__tests__/sampleMarkdown.md", "test.md"];
+  const expected = ["articles/test.md"];
 
   expect(markdownFiles).toEqual(expected);
 });

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -31,7 +31,10 @@ export async function getChangedFiles(githubSha: string): Promise<string[]> {
 }
 
 export function getMarkdowns(changedFiles: string[]): string[] {
-  return changedFiles.filter((filePath) => filePath.endsWith(".md"));
+  // articles 以下の Markdown ファイルのみを抽出
+  return changedFiles.filter(
+    (filePath) => filePath.endsWith(".md") && filePath.startsWith("articles/"),
+  );
 }
 
 export async function updateZennMetadata(


### PR DESCRIPTION
This pull request includes changes to the handling of Markdown files in the repository. The changes focus on organizing Markdown files into an `articles` directory and updating related functions and tests accordingly.

Changes to file handling:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L98-R99): Updated the workflow to create an `articles` directory and copy the `invalidMarkdown.md` file into it.

Updates to tests:

* [`src/__tests__/main.test.ts`](diffhunk://#diff-928565d85fc99c7f0ed1e4baa41c0ffeb85b7f68d875a06d79bf77bb7a477034L28-R31): Modified the `getMarkdowns` test to reflect the new location of Markdown files under the `articles` directory.

Function modifications:

* [`src/functions.ts`](diffhunk://#diff-bf8986a545cc729a5e76191a9d4afa2f63cf28a132f238413ce8349b7da44813L34-R37): Updated the `getMarkdowns` function to filter and return only Markdown files located under the `articles` directory.